### PR TITLE
Add support for any composer command and all of the parameters.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,21 +3,46 @@ var gutil 	= require('gulp-util');
 var shelljs	= require('shelljs/global');
 var through = require('through2');
 
-module.exports = function (opts) {
+module.exports = function (cmd, opts) {
+	if ( arguments.length < 2 ) { // both arguments weren't supplied
+		opts = cmd; // shift in case opts were supplied
+		cmd = 'install'; // default command is install
+	}
+
+	opts = opts || {}; // options needs to be an object
+
+	//cwd legacy support, but switch to using 'd' parameter key
+	opts.d = opts.d || opts.cwd || process.cwd();
+	delete opts.cwd; // avoid sending cwd parameter
+
+	var bin = opts.bin || 'composer';
+	delete opts.bin; // avoid sending bin parameter
 
 	var stream = through.obj(function(file, enc, callback) {
 		this.push(file);
 		callback();
 	});
 
-	opts = opts || {};
+	var command = [bin, cmd]; // initialize command array
 
-	opts.cwd = opts.cwd || process.cwd();
-	opts.bin = opts.bin || 'composer';
+	var keys = Object.keys( opts );
+	for( var i = 0, length = keys.length; i < length; i++ ) {
+	    
+	    if(opts[ keys[ i ] ]){ //handle false case if passed in explicitly
+	    	var parameter = ((keys[ i ].length == 1)?'-':'--'); // use - for d, w, n, etc.
+	    	parameter += keys[ i ]; // add parameter name
+	    	if( typeof opts[ keys[ i ] ] != 'boolean'){
+	    		parameter += ' ' + opts[ keys[ i ] ];
+	    	}
+	    	command.push( parameter ); // add parameter to command array
+	    }	   
+	}
 
-	gutil.log("Using cwd: ", opts.cwd);
-	var commandToRun = opts.bin+" -d="+opts.cwd+" install";
+	var commandToRun = command.join(' '); // combine composer command and parameters
+
+	gutil.log("Using cwd: ", opts.d);
 	gutil.log("Running Composer Command: ", commandToRun);
+	
 	exec(commandToRun, {silent:true}, function(code, output) {
 		if (code != 0)
 			stream.emit('error', new gutil.PluginError('gulp-composer', output));


### PR DESCRIPTION
This updates the function to accept new params and uses those to provide support for other commands besides the current default install.

I kept install as the default and tried to keep full support for backwards compatibility with previous command structure while supporting other build steps.

One example would be using composer to clean up before distribution. If you don't simply transfer the lock file you would still want to fix up the autoloader for performance. Below is an example task which uses the new format to prepare the composer components for production:

```
gulp.task('optimize', function() {
    $.composer('dump-autoload', {'optimize':true});
});
```

There are many number of things this might be used for, but this was one important step that was needed by myself and maybe others.
