### PR TITLE
autoloads composer, verbose logging and colors, bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ if (gutils.env.production) {
 composer("dumpautoload", {optimize: true});
 ```
 
+## Contributors
+
++ Tom Westcott <tom.westcott@gmail.com>
++ Nathan J. Brauer <nathan@marketera.com>
++ Joseph Richardson <jrichardson@zingermans.com>
+
 [install-composer]: https://getcomposer.org/doc/00-intro.md
 [cwd]:              https://nodejs.org/api/process.html#process_process_cwd
 [options]:          #options

--- a/README.md
+++ b/README.md
@@ -3,25 +3,29 @@
 
 ## Install
 
-## Examples
+    npm install --save-dev gulp-composer
+
+## Usage
 
 ```js
 composer = require('gulp-composer');
-
-gulp.task('composer', function () {
-	composer({ cwd: './php-stuff', bin: 'composer' });
-});
-```
-More involved example
-```js
-	var composer = require('gulp-composer');
-	composer('init', {'no-interaction':true});
-	composer('require "codeception/codeception:*"', {});
-	composer(); //default install
-	composer('dumpautoload', {optimize: true});
+composer([ command, ] [ options ]);
 ```
 
-### Options
+## Parameters
+
+### `command` - The composer command to execute
+
+> Type: *String*
+
+> Options: See `composer --help` for list of available commands
+
+> Default: `install`
+
+### `options` - All options for `gulp-composer` and native `composer`
+
+> Type: *Object*
+
 #### options.cwd
 Type: `String`
 
@@ -32,3 +36,30 @@ Type: `String`
 Default value: `composer`
 
 This is where the composer binary is located. Also possible to add things like "php /somewhere/composer".
+
+## Examples
+Most basic setup:
+```js
+var composer = require('gulp-composer');
+
+gulp.task('composer', function () {
+	composer();
+});
+```
+Adding a few options:
+```js
+var composer = require('gulp-composer');
+
+gulp.task('composer', function () {
+	composer({ cwd: './php-stuff', bin: 'composer' });
+});
+```
+A more complex setup involving non-default commands:
+```js
+var composer = require('gulp-composer');
+
+composer('init', {'no-interaction':true});
+composer('require "codeception/codeception:*"', {});
+composer(); //default install
+composer('dumpautoload', {optimize: true});
+```

--- a/README.md
+++ b/README.md
@@ -1,9 +1,22 @@
 # gulp-composer
-> Install composer files.
+> Install composer packages from within gulp, even without composer itself installed on the system.
 
 ## Install
 
-    npm install --save-dev gulp-composer
+    npm i gulp-composer --save-dev
+
+## Requirements
+
+ - PHP (obviously)
+   
+   > PHP 5.3.2 or above (at least 5.3.4 recommended to avoid potential bugs)
+   > 
+   > <cite>https://github.com/composer/composer#requirements</cite>
+
+## Recommended
+Part of the magic of `gulp-composer` is that having `composer` [installed on the system][install-composer] is *not required*!  However, it is still recommended as it will increase performance of the task.
+ - By default, `gulp-composer` will search for composer in `{working-dir}/composer.phar`.  If it's not found, it will attempt to use the globally installed `composer` command.
+ - If `composer(.phar)` is still not found on the system, it will attempt to download it to the system temp directory. Future builds will check the system temp directory so it doesn't download it too often.
 
 ## Usage
 
@@ -14,52 +27,76 @@ composer([ command, ] [ options ]);
 
 ## Parameters
 
-### `command` - The composer command to execute
+| Parameter                       | Default       | Description                                                                           |
+|:------------------------------- |:------------- |:------------------------------------------------------------------------------------- |
+| command <br><sup>*String*</sup> | install       | The composer command to execute. See `composer --help` for list of available commands |
+| options <br><sup>*Object*</sup> | see [options] | All options for `gulp-composer` and native `composer`                                 |
 
-> Type: *String*
+#### Options
 
-> Options: See `composer --help` for list of available commands
+| Option                                | Default | Description                                                                                         | Passed to composer |
+|:------------------------------------- |:------- |:--------------------------------------------------------------------------------------------------- |:------------------ |
+| working-dir  <br><sup>*String*</sup>  | [cwd]   | The path with which to run composer against (normally where the composer.json is located).          | *Yes*              |
+| bin          <br><sup>*String*</sup>  | auto    | Path to the composer binary. E.g. `composer`, `/usr/bin/composer.phar`, or `php /path/to/composer`. | *No*               |
+| self-install <br><sup>*Boolean*</sup> | true    | Set to `false` if you prefer to disable the self-install feature.                                   | *No*               |
+| ansi         <br><sup>*Boolean*</sup> | true    | The default for this parameter is automatically passed `composer` to enable logging in color        | *Yes*              |
+| ...                                   | *mixed* | Any other arguments will be passed through to composer                                              | *Yes*              |
 
-> Default: `install`
-
-### `options` - All options for `gulp-composer` and native `composer`
-
-> Type: *Object*
-
-#### options.cwd
-Type: `String`
-
-This is the working directory, normally where the composer.json is located (default to current).
-
-#### options.bin
-Type: `String`
-Default value: `composer`
-
-This is where the composer binary is located. Also possible to add things like "php /somewhere/composer".
 
 ## Examples
 Most basic setup:
 ```js
-var composer = require('gulp-composer');
+var composer = require("gulp-composer");
 
-gulp.task('composer', function () {
+gulp.task("composer", function () {
 	composer();
 });
 ```
-Adding a few options:
-```js
-var composer = require('gulp-composer');
 
-gulp.task('composer', function () {
-	composer({ cwd: './php-stuff', bin: 'composer' });
+Most basic setup with self-install disabled:
+```js
+var composer = require("gulp-composer");
+
+gulp.task("composer", function () {
+	composer({ "self-install": false });
 });
 ```
-A more complex setup involving non-default commands:
-```js
-var composer = require('gulp-composer');
 
-composer('init', {'no-interaction':true});
-composer('require "codeception/codeception:*"', {});
-composer(); //default install
-composer('dumpautoload', {optimize: true});
+Adding a few options:
+```js
+var composer = require("gulp-composer");
+
+gulp.task("composer", function () {
+	composer({
+		"working-dir": "./php-stuff",
+		bin: "composer"
+	});
+});
 ```
+A more complex setup:
+```js
+var composer = require("gulp-composer"),
+	gutils = require("gulp-utilities");
+
+// ...
+
+composer("init", { "no-interaction": true });
+composer('require "codeception/codeception:*"', {});
+
+if (gutils.env.production) {
+	composer({
+		"bin":          "/build/share/composer.phar",
+		"no-ansi":      true,
+		"self-install": false,
+	});
+} else {
+	//default install
+	composer();
+}
+
+composer("dumpautoload", {optimize: true});
+```
+
+[install-composer]: https://getcomposer.org/doc/00-intro.md
+[cwd]:              https://nodejs.org/api/process.html#process_process_cwd
+[options]:          #options

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ module.exports = function (cmd, opts) {
 	bin = opts.bin || (function(){
 			var self_install_cmd,
 				self_install_dir  = tempdir(),
-				self_install_file = 'composer.phar',
+				self_install_file = 'gulp-composer.phar',
 				self_install_path = self_install_dir + '/' + self_install_file,
 				self_install_options = build_arguments({
 					'install-dir': self_install_dir,

--- a/index.js
+++ b/index.js
@@ -1,52 +1,167 @@
-'use strict'
-var gutil 	= require('gulp-util');
-var shelljs	= require('shelljs/global');
-var through = require('through2');
+'use strict';
+var gutil 	= require('gulp-util'),
+	shelljs	= require('shelljs/global'),
+	through = require('through2'),
 
-module.exports = function (cmd, opts) {
-	if ( arguments.length < 2 ) { // both arguments weren't supplied
-		opts = cmd; // shift in case opts were supplied
-		cmd = 'install'; // default command is install
-	}
-
-	opts = opts || {}; // options needs to be an object
-
-	//cwd legacy support, but switch to using 'd' parameter key
-	opts.d = opts.d || opts.cwd || process.cwd();
-	delete opts.cwd; // avoid sending cwd parameter
-
-	var bin = opts.bin || 'composer';
-	delete opts.bin; // avoid sending bin parameter
-
-	var stream = through.obj(function(file, enc, callback) {
+	stream = through.obj(function(file, enc, callback) {
 		this.push(file);
 		callback();
-	});
+	}),
 
-	var command = [bin, cmd]; // initialize command array
+	build_arguments = function(opts) {
+		var args = []; // initialize command array
 
-	var keys = Object.keys( opts );
-	for( var i = 0, length = keys.length; i < length; i++ ) {
-		if(opts[ keys[ i ] ]) { //handle false case if passed in explicitly
-			var parameter = ((keys[ i ].length == 1)?'-':'--'); // use - for d, w, n, etc.
-			parameter += keys[ i ]; // add parameter name
-			if ( typeof opts[ keys[ i ] ] != 'boolean') {
-				parameter += ' ' + opts[ keys[ i ] ];
+		var keys = Object.keys( opts );
+		for( var i = 0, length = keys.length; i < length; i++ ) {
+			if(opts[ keys[ i ] ]) { //handle false case if passed in explicitly
+				var parameter = ((keys[ i ].length == 1)?'-':'--'); // use - for d, w, n, etc.
+				parameter += keys[ i ]; // add parameter name
+				if ( typeof opts[ keys[ i ] ] != 'boolean') {
+					parameter += ' ' + opts[ keys[ i ] ];
+				}
+				args.push( parameter ); // add parameter to command array
 			}
-			command.push( parameter ); // add parameter to command array
+		}
+		return args.join(' ');
+	},
+	log_indent = '|   ',
+	log_exec = function(output) {
+		var output_lines = output.replace(/^\s+|\s+$/,'').split(/[\n\r]+/),// Trims the output and returns it split into an array of lines
+			log_line;
+		if (output) {
+			for (log_line = 0; log_line < output_lines.length; ++log_line) {
+				gutil.log(log_indent,output_lines[log_line]);
+			}
+		}
+	};
+
+if (!which('php')) {
+	stream.emit('error', new gutil.PluginError('gulp-composer', "PHP is a composer requirement and therefore it is required to use gulp-composer."));
+}
+module.exports = function (cmd, opts) {
+	var bin, commandToRun, cwd;
+
+	if (typeof cmd === 'undefined' || typeof cmd === 'object') {
+		// Looks like this was called with either no parameters
+		// or the options were passed through the first parameter
+		// In this case, we'll ignore all subsequent params
+		opts = cmd || {};
+		cmd = 'install';
+	} else {
+		// Make sure opts is set
+		opts = opts || {};
+	}
+
+	// cwd legacy support
+	cwd = opts['working-dir'] || opts.d || opts.cwd || process.cwd();
+
+	// using --working-dir=xxxx instead of -d makes logging clearer
+	// and allows us to remove an unneeded `gutil.log` line
+	opts['working-dir'] = cwd;
+
+	delete opts.cwd; // avoid sending cwd parameter
+	delete opts.d;   // avoid sending duplicate -d parameter
+
+	// To default to `true` for historical purposes, uncomment the following block
+	//if (typeof opts.quiet == 'undefined') {
+	//	 opts.quiet = true;
+	//}
+
+	// Ensure opts.quiet is a bool
+	opts.quiet = !!opts.quiet;
+
+	if (!opts.quiet) {
+		// Turn colors on by default
+		if (!opts['no-ansi'] && typeof opts.ansi === 'undefined') {
+			opts.ansi = true;
 		}
 	}
 
-	var commandToRun = command.join(' '); // combine composer command and parameters
+	bin = opts.bin || (function(){
+			var self_install,
+				self_install_dir  = tempdir(),
+				self_install_file = 'composer.phar',
+				self_install_path = self_install_dir + '/' + self_install_file,
+				self_install_options = build_arguments({
+					'install-dir': self_install_dir,
+					'filename':    self_install_file,
+					'quiet':       opts.quiet,
+					'ansi':        opts.ansi,
+					'no-ansi':    !opts.ansi
+				}),
+				self_install_alert = function () {
+					gutil.log();
+					gutil.log(gutil.colors.yellow.inverse(" Significantly improve performance by installing composer on this machine. "));
+					gutil.log(gutil.colors.yellow.inverse(" Installation: ") + gutil.colors.yellow.underline.inverse("https://getcomposer.org/doc/00-intro.md") + gutil.colors.yellow.inverse("                     "));
+					gutil.log();
+				};
 
-	gutil.log("Using cwd: ", opts.d);
-	gutil.log("Running Composer Command: ", commandToRun);
-	
+			// Use composer.phar if it exists locally...
+			if (test('-e',cwd + '/composer.phar')) {
+				gutil.log(gutil.colors.green("Defaulting to locally installed " + cwd + "/composer.phar..."));
+				return cwd + '/composer.phar';
+			}
+
+			// Otherwise use composer if it's installed globally...
+			if (which('composer')) {
+				gutil.log(gutil.colors.green("Defaulting to globally installed composer..."));
+				return 'composer';
+			}
+			gutil.log(gutil.colors.yellow("Composer is not available globally."));
+
+			if (test('-e', self_install_path)) {
+				gutil.log(gutil.colors.yellow("Loading composer from system temp directory..."));
+				self_install_alert();
+				return self_install_path;
+			}
+
+			gutil.log(gutil.colors.yellow("Composer is not available locally, either."));
+
+			// It doesn't exist, so we'll attempt to download it locally and delete it afterward
+			if (self_install_options) {
+				self_install_options = ' -- ' + self_install_options;
+			}
+
+			gutil.log(gutil.colors.magenta.inverse(" Attempting to download composer to system temp directory...               "));
+			self_install = exec('php -r "readfile(\'https://getcomposer.org/installer\');" | php' + self_install_options, { async: false, silent: true });
+
+			if (self_install.code != 0) {
+				stream.emit('error', new gutil.PluginError('gulp-composer', self_install.output));
+			}
+			log_exec(self_install.output);
+
+			if (ls(self_install_path)[0]) {
+				gutil.log(gutil.colors.magenta.inverse(" Successfully downloaded!                                                  "));
+				self_install_alert();
+				return self_install_path;
+			}
+
+			gutil.log(gutil.colors.red.inverse("Failed to download. All options have been exhausted."));
+			gutil.log(gutil.colors.red.inverse("Installation instructions: ") + gutil.colors.blue.underline.inverse("https://getcomposer.org/doc/00-intro.md"));
+
+			return '';
+		})();
+	delete opts.bin; // avoid sending bin parameter
+
+	if (!bin) {
+		stream.emit('error', new gutil.PluginError('gulp-composer', "Composer executable does not exist. Please install before continuing."));
+	}
+
+
+	// build the command array
+	commandToRun = [bin, cmd, build_arguments(opts)].join(' ');
+	gutil.log(gutil.colors.red(commandToRun));
+	gutil.log();
+	gutil.log(gutil.colors.cyan.inverse(" Executing composer...                                                     "));
+
 	exec(commandToRun, {silent:true}, function(code, output) {
-		if (code != 0)
+		if (code != 0) {
 			stream.emit('error', new gutil.PluginError('gulp-composer', output));
-		else
-			gutil.log("Composer Completed");
+		}
+
+		log_exec(output);
+
+		gutil.log(gutil.colors.cyan.inverse(" Composer completed.                                                       "));
 
 		stream.end();
 		stream.emit("end");

--- a/index.js
+++ b/index.js
@@ -83,6 +83,10 @@ module.exports = function (cmd, opts) {
 		}
 	}
 
+	if (opts.bin == 'auto') {
+		delete opts.bin;
+	}
+
 	bin = opts.bin || (function(){
 			var self_install_cmd,
 				self_install_dir  = tempdir(),


### PR DESCRIPTION
 - require that PHP exist on the system
 - prefer more verbose argument keys rather than shorthand (easier to know what's going on)
 - allow users to control whether composer output is displayed or not through --quiet option
 - if no `bin` is set, automatically detect composer. It attempts to load in the following order...
    - `$PWD/composer.phar`
    - global install
    - `tempdir() + '/composer.phar'` (in the system `tempdir`)
    - if all else fails, it attempts to download it temporarily to `tempdir() + '/composer.phar'`
 - a few bug fixes (fixes #2 and #3, and builds further upon #1)
 - code cleanup
 - default to displaying `composer` output
 - enable `composer` colors by default

## A few tasks I need to do before you accept this merge:

 - [x] Add option to disable self-installer
 - [x] Namespace `composer.phar` to prevent collisions
 - [x] Finish writing readme
 - [x] Add contributors