### PR TITLE
Fix logging of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,7 +191,7 @@ module.exports = function (cmd, opts) {
     // build the command array
     commandToRun = [bin, cmd, build_arguments(opts)].join(' ');
     gutil.log(gutil.colors.red(commandToRun));
-    gutil.log();
+    gutil.log('');
     gutil.log(gutil.colors.cyan.inverse(" Executing composer...                                                     "));
 
     if (async) {


### PR DESCRIPTION
The empty `gutil.log()` was causing an `undefined` to be logged. Presumably at one point this logged a blank line, but it seems to have been refactored now and logs the string `undefined`.

```
$ gulp build:composer
[18:34:16] Using gulpfile ~/projects/test/gulpfile.js
[18:34:16] Starting 'composer'...
[18:34:16] Composer is not available locally.
[18:34:16] Defaulting to globally installed composer...
[18:34:16] composer install --no-interaction --no-dev --optimize-autoloader --no-scripts --working-dir ./build --ansi
[18:34:16] undefined
[18:34:16]  Executing composer...                                                     
[18:34:19] |    Loading composer repositories with package information
[18:34:19] |    Installing dependencies from lock file
[18:34:19] |    Nothing to install or update
[18:34:19] |    Generating optimized autoload files
[18:34:19]  Composer completed.                                                       
[18:34:19] Finished 'composer' after 2.91 s
```
