### PR TITLE
Copy stderr to output if output is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -203,6 +203,7 @@ module.exports = function (cmd, opts) {
             silent: true,
             async: false
         });
+        if(typeof execReturn.output === 'undefined') execReturn.output = execReturn.stderr;
         handle_exec(execReturn.code, execReturn.output);
     }
 

--- a/index.js
+++ b/index.js
@@ -29,9 +29,9 @@ var build_arguments = function (opts) {
     },
     log_indent = '|   ',
     log_exec = function (output) {
-        var output_lines = output.replace(/^\s+|\s+$/, '').split(/[\n\r]+/), // Trims the output and returns it split into an array of lines
-            log_line;
+        var output_lines, log_line;
         if (output) {
+            output_lines =  = output.replace(/^\s+|\s+$/, '').split(/[\n\r]+/); // Trims the output and returns it split into an array of lines
             for (log_line = 0; log_line < output_lines.length; log_line += 1) {
                 gutil.log(log_indent, output_lines[log_line]);
             }


### PR DESCRIPTION
If all output is sent to stderr, output will be empty and cause a TypeError. This copies the stderr messages to output before that and the error is avoided, plus additional information is sent to the user.

Example: All packages are up to date when running composer install:

gulpfile:
```
gulp.task('composer', function (callback) {
  composer('install', {
    'working-dir': './dist',
    'async':       false,
    'no-dev':      true
  });
  callback();
});
```


Before:
```
[12:27:07] Starting 'composer'...
[12:27:07] Composer is not available locally.
[12:27:07] Defaulting to globally installed composer...
[12:27:07] composer install --working-dir ./dist --no-dev --ansi
[12:27:07]
[12:27:07]  Executing composer...
[12:27:08] 'composer' errored after 601 ms
[12:27:08] TypeError: Cannot read property 'replace' of undefined
    at log_exec (/Users/aleksi-kallio/demoProject/node_modules/gulp-composer/index.js:32:34)
    at handle_exec (/Users/aleksi-kallio/demoProject/node_modules/gulp-composer/index.js:55:13)
    at module.exports (/Users/aleksi-kallio/demoProject/node_modules/gulp-composer/index.js:206:9)
    at Gulp.<anonymous> (/Users/aleksi-kallio/demoProject/gulpfile.js:85:3)
    at module.exports (/Users/aleksi-kallio/demoProject/node_modules/orchestrator/lib/runTask.js:34:7)
    at Gulp.Orchestrator._runTask (/Users/aleksi-kallio/demoProject/node_modules/orchestrator/index.js:273:3)
    at Gulp.Orchestrator._runStep (/Users/aleksi-kallio/demoProject/node_modules/orchestrator/index.js:214:10)
    at Gulp.Orchestrator.start (/Users/aleksi-kallio/demoProject/node_modules/orchestrator/index.js:134:8)
    at /usr/local/lib/node_modules/gulp/bin/gulp.js:129:20
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
```


After:
```
[12:30:14] Starting 'composer'...
[12:30:14] Composer is not available locally.
[12:30:14] Defaulting to globally installed composer...
[12:30:14] composer install --working-dir ./dist --no-dev --ansi
[12:30:14]
[12:30:14]  Executing composer...
[12:30:15] |    Loading composer repositories with package information
[12:30:15] |    Installing dependencies from lock file
[12:30:15] |    Nothing to install or update
[12:30:15] |    Generating autoload files
[12:30:15]  Composer completed.
[12:30:15] Finished 'composer' after 739 ms
```